### PR TITLE
Feature/lbresult first failure

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -8,6 +8,6 @@
   </component>
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.3.10" />
+    <option name="version" value="2.3.20" />
   </component>
 </project>

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres    
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2026-04-16
+
+```
+LbCore 4.10.0
+```
+
+- Add `firstFailure` extension on `LBResult` collection to extract the first failure
+
 ## 2026-03-31
 
 ```

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -67,7 +67,7 @@ object AndroidConfig {
     const val LBCPRESENTER_KSP_VERSION: String = "2.0.0-rc01"
     const val LBCROBOLECTRICTEST_VERSION: String = "1.1.0"
     const val LOGGER_KERMIT_VERSION: String = "4.9.0"
-    const val CORE_VERSION: String = "4.9.0"
+    const val CORE_VERSION: String = "4.10.0"
     const val EXTENSIONS_VERSION: String = "4.9.0"
     const val TEST_VERSION: String = "4.9.0"
     const val KTOR_VERSION: String = "4.9.0"

--- a/common/core/core/build.gradle.kts
+++ b/common/core/core/build.gradle.kts
@@ -33,6 +33,10 @@ kotlin {
 
             api(projects.loggerKermit)
         }
+        commonTest.dependencies {
+            implementation(libs.kotlinTest)
+            implementation(libs.kotlinxCoroutinesTest)
+        }
         jvmTest.dependencies {
             implementation(project.dependencies.platform(libs.junitJupiterBom))
 

--- a/common/core/core/src/commonMain/kotlin/studio/lunabee/core/model/LBResult.kt
+++ b/common/core/core/src/commonMain/kotlin/studio/lunabee/core/model/LBResult.kt
@@ -76,7 +76,7 @@ sealed class LBResult<out T> {
 }
 
 /**
- * Returns the first failure
+ * @return the first failure or null if none
  */
 fun <T> Collection<LBResult<T>>.firstFailure(): LBResult.Failure<T>? {
     return this.filterIsInstance<LBResult.Failure<T>>().firstOrNull()

--- a/common/core/core/src/commonMain/kotlin/studio/lunabee/core/model/LBResult.kt
+++ b/common/core/core/src/commonMain/kotlin/studio/lunabee/core/model/LBResult.kt
@@ -74,3 +74,10 @@ sealed class LBResult<out T> {
         is Failure -> LBFlowResult.Failure(throwable, failureData)
     }
 }
+
+/**
+ * Returns the first failure
+ */
+fun <T> Collection<LBResult<T>>.firstFailure(): LBResult.Failure<T>? {
+    return this.filterIsInstance<LBResult.Failure<T>>().firstOrNull()
+}

--- a/common/core/core/src/commonTest/kotlin/studio/lunabee/core/model/LBResultTest.kt
+++ b/common/core/core/src/commonTest/kotlin/studio/lunabee/core/model/LBResultTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Lunabee Studio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package studio.lunabee.core.model
+
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class LBResultTest {
+
+    @Test
+    fun firstFailure_test() {
+        val success1 = LBResult.Success("Success 1")
+        val failure1 = LBResult.Failure<String>("Failure 1")
+        val success2 = LBResult.Success("Success 2")
+        val failure2 = LBResult.Failure<String>("Failure 2")
+
+        val list = listOf(success1, failure1, success2, failure2)
+        val firstFailure = list.firstFailure()
+        assertSame(failure1, firstFailure)
+    }
+
+    @Test
+    fun firstFailure_no_failure_test() {
+        val success1 = LBResult.Success("Success 1")
+        val success2 = LBResult.Success("Success 2")
+
+        val list = listOf(success1, success2)
+        val firstFailure = list.firstFailure()
+        assertNull(firstFailure)
+    }
+}


### PR DESCRIPTION
## 📜 Description

- Add `firstFailure` extension on `LBResult` collection to extract the first failure

## 💡 Motivation and Context

- Useful to show only the first error of many remote calls

## 💚 How did you test it?

- Unit tests

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
