### PR TITLE
fix: skip jar artifact for new KMP native targets in JReleaser

### DIFF
--- a/build-logic/src/main/kotlin/lunabee.library-publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/lunabee.library-publish-conventions.gradle.kts
@@ -71,6 +71,18 @@ jreleaser {
                         artifactId.set("${project.name.get()}-iossimulatorarm64")
                         this.jar = false
                     }
+                    artifactOverride {
+                        artifactId.set("${project.name.get()}-macosarm64")
+                        this.jar = false
+                    }
+                    artifactOverride {
+                        artifactId.set("${project.name.get()}-linuxx64")
+                        this.jar = false
+                    }
+                    artifactOverride {
+                        artifactId.set("${project.name.get()}-mingwx64")
+                        this.jar = false
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- PR #294 added `macosArm64`, `linuxX64`, and `mingwX64` targets to `common/core/core`.
- The JReleaser workaround for [jreleaser/jreleaser#1746](https://github.com/jreleaser/jreleaser/issues/1746) only declared `jar = false` overrides for the iOS targets.
- Maven Central publication of `core` 4.11.0 failed ([Publish build #38209](https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_Publish/38209)) with:
  ```
  core-mingwx64-4.11.0.jar is missing
  core-macosarm64-4.11.0.jar is missing
  core-linuxx64-4.11.0.jar is missing
  ```
- This PR adds matching `artifactOverride` blocks for the three new native targets.

## Test plan

- [ ] Re-run the `Publish` TeamCity build on master after merge and confirm `core` 4.11.0 reaches Maven Central.