### PR TITLE
docs: fix wrong artifact coordinates in module READMEs

### DIFF
--- a/common/ktor/README.md
+++ b/common/ktor/README.md
@@ -51,10 +51,10 @@ This plugin installs, under the hood, `Logging` plugin configured with our Kermi
 
 To use it in your application (KMP or not), you need to add the following dependencies (depending on your need):
 ```libs.gradle.toml
-lunabee-bom = { group = "studio.lunabee", name = "lunabee-bom", version.ref = "lunabee-bom" }
-lbktor-core = { group = "studio.lunabee", name = "lbktor-core" }
-lbktor-json = { group = "studio.lunabee", name = "lbktor-json" }
-lbktor-kermit = { group = "studio.lunabee", name = "lbktor-kermit" }
+lunabee-bom = { group = "studio.lunabee", name = "bom", version.ref = "lunabee-bom" }
+lbktor-core = { group = "studio.lunabee.ktor", name = "ktor-core" }
+lbktor-json = { group = "studio.lunabee.ktor", name = "ktor-json" }
+lbktor-kermit = { group = "studio.lunabee.ktor", name = "ktor-kermit" }
 
 ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor" }
 ktor-client-ios = { group = "io.ktor", name = "ktor-client-ios", version.ref = "ktor" }

--- a/common/monitoring/README.md
+++ b/common/monitoring/README.md
@@ -50,7 +50,7 @@ setContent {
 
 To use it in your application (KMP or not), you need to add the following dependencies (depending on your need):
 ```libs.gradle.toml
-lunabee-bom = { group = "studio.lunabee", name = "lunabee-bom", version.ref = "lunabee-bom" }
+lunabee-bom = { group = "studio.lunabee", name = "bom", version.ref = "lunabee-bom" }
 monitoring-core = { group = "studio.lunabee.monitoring", name = "monitoring-core" }
 monitoring-room = { group = "studio.lunabee.monitoring", name = "monitoring-room" }
 monitoring-ui = { group = "studio.lunabee.monitoring", name = "monitoring-ui" }
@@ -75,7 +75,7 @@ private val httpClient: HttpClient = HttpClient(Android) {
 ```
 
 ```libs.gradle.toml
-lunabee-bom = { group = "studio.lunabee", name = "lunabee-bom", version.ref = "lunabee-bom" }
-monitoring-ktor = { group = "studio.lunabee", name = "monitoring-ktor" }
+lunabee-bom = { group = "studio.lunabee", name = "bom", version.ref = "lunabee-bom" }
+monitoring-ktor = { group = "studio.lunabee.monitoring", name = "monitoring-ktor" }
 ```
 


### PR DESCRIPTION
## What

Corrects wrong Maven coordinates in module READMEs.

### `common/ktor/README.md`
| Before | Actual |
|---|---|
| `studio.lunabee:lbktor-core` | `studio.lunabee.ktor:ktor-core` |
| `studio.lunabee:lbktor-json` | `studio.lunabee.ktor:ktor-json` |
| `studio.lunabee:lbktor-kermit` | `studio.lunabee.ktor:ktor-kermit` |
| `studio.lunabee:lunabee-bom` | `studio.lunabee:bom` |

### `common/monitoring/README.md`
| Before | Actual |
|---|---|
| `studio.lunabee:lunabee-bom` (x2) | `studio.lunabee:bom` |
| `studio.lunabee:monitoring-ktor` (Ktor block) | `studio.lunabee.monitoring:monitoring-ktor` |

All verified against `PrintCoordinates`. Catalog aliases left unchanged so accessor usage further down each README stays valid.

### Reviewed, no change needed
- Root `README.md` — coordinates correct.
- `compose/presenter/README.MD`, `compose/glance/README.md` — no coordinates listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)