### PR TITLE
Add Root option to popupTo for Navigation library

### DIFF
--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="45ac5549:1963f430c84:-7ff1" />
+      </MTProjectMetadataState>
+    </option>
+  </component>
+</project>

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres    
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2026-0610
+
+```
+LbcNavigation 1.1.0
+```
+
+Add a `Root` option to the `popupTo` to argument allowing to clear the backstack up until the first destination.
+
 ## 2026-06-05
 
 ```
@@ -29,7 +37,8 @@ Lbktor 4.10.0
 Lbloading 4.10.0
 ```
 
-- Add Kotlin/Native desktop targets (`macosArm64`, `linuxX64`, `mingwX64`) to `core`, `logger-kermit`, `extension`, `ktor`, and `loading` so they can be consumed from native CLI binaries.
+- Add Kotlin/Native desktop targets (`macosArm64`, `linuxX64`, `mingwX64`) to `core`, `logger-kermit`, `extension`, `ktor`, and `loading` so
+  they can be consumed from native CLI binaries.
 - Add `demo-cli` module: a minimal Kotlin/Native CLI chronometer that demonstrates `LBFlowResult` + coroutines on native targets, with
   optional `--verbose` Kermit logging.
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,6 +13,9 @@ LbcNavigation 1.1.0
 
 Add a `Root` option to the `popupTo` to argument allowing to clear the backstack up until the first destination.
 
+Expose `transitionSpec`, `popTransitionSpec` and `predictivePopTransitionSpec` parameters on `LbcNavHost` so callers can
+override the navigation animations, keeping the existing ones as defaults.
+
 ## 2026-06-05
 
 ```

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -66,7 +66,7 @@ object AndroidConfig {
     const val LBCPRESENTER_KOIN_VERSION: String = "2.0.0-rc01"
     const val LBCPRESENTER_KSP_VERSION: String = "2.0.0-rc03"
     const val LBCPRESENTER_KOIN_KSP_VERSION: String = LBCPRESENTER_KSP_VERSION
-    const val LBCNAVIGATION_VERSION: String = "1.0.0"
+    const val LBCNAVIGATION_VERSION: String = "1.1.0"
     const val LBCROBOLECTRICTEST_VERSION: String = "1.1.0"
     const val LOGGER_KERMIT_VERSION: String = "4.10.0"
     const val CORE_VERSION: String = "4.11.0"

--- a/compose/navigation/src/main/kotlin/studio/lunabee/compose/navigation/LbcNavHost.kt
+++ b/compose/navigation/src/main/kotlin/studio/lunabee/compose/navigation/LbcNavHost.kt
@@ -16,6 +16,8 @@
 
 package studio.lunabee.compose.navigation
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.layout.Box
@@ -35,6 +37,7 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
+import androidx.navigation3.scene.Scene
 import androidx.navigation3.ui.NavDisplay
 import androidx.navigationevent.NavigationEvent
 import studio.lunabee.compose.navigation.utils.LocalModalBackgroundColor
@@ -51,6 +54,11 @@ fun LbcNavHost(
     navigationHelper: NavigationHelper,
     modalBackgroundColor: Color,
     onBack: () -> Unit = { backStack.removeLastOrNull() },
+    transitionSpec: AnimatedContentTransitionScope<Scene<LbcNavigationKey>>.() -> ContentTransform = { normalPushTransition() },
+    popTransitionSpec: AnimatedContentTransitionScope<Scene<LbcNavigationKey>>.() -> ContentTransform = { normalPopTransition() },
+    predictivePopTransitionSpec:
+    AnimatedContentTransitionScope<Scene<LbcNavigationKey>>.(@NavigationEvent.SwipeEdge Int) -> ContentTransform =
+        { _: @NavigationEvent.SwipeEdge Int -> normalPredictivePopTransition() },
 ) {
     val bottomSheetStrategy = remember { ModalSceneStrategy<LbcNavigationKey>() }
 
@@ -64,9 +72,9 @@ fun LbcNavHost(
                     backStack = backStack,
                     sceneStrategies = listOf(bottomSheetStrategy),
                     onBack = onBack,
-                    transitionSpec = { normalPushTransition() },
-                    popTransitionSpec = { normalPopTransition() },
-                    predictivePopTransitionSpec = { _: @NavigationEvent.SwipeEdge Int -> normalPredictivePopTransition() },
+                    transitionSpec = transitionSpec,
+                    popTransitionSpec = popTransitionSpec,
+                    predictivePopTransitionSpec = predictivePopTransitionSpec,
                     entryDecorators = listOf(
                         rememberSaveableStateHolderNavEntryDecorator(),
                         rememberViewModelStoreNavEntryDecorator(),

--- a/compose/navigation/src/main/kotlin/studio/lunabee/compose/navigation/NavigationHelper.kt
+++ b/compose/navigation/src/main/kotlin/studio/lunabee/compose/navigation/NavigationHelper.kt
@@ -52,9 +52,8 @@ class NavigationHelper(
             is PopUpTo.Root -> {
                 if (popupTo.inclusive) {
                     backStack.clear()
-                } else {
+                } else if (backStack.size > 1) {
                     backStack.subList(1, backStack.size).clear()
-
                 }
             }
 

--- a/compose/navigation/src/main/kotlin/studio/lunabee/compose/navigation/NavigationHelper.kt
+++ b/compose/navigation/src/main/kotlin/studio/lunabee/compose/navigation/NavigationHelper.kt
@@ -49,6 +49,15 @@ class NavigationHelper(
                 }
             }
 
+            is PopUpTo.Root -> {
+                if (popupTo.inclusive) {
+                    backStack.clear()
+                } else {
+                    backStack.subList(1, backStack.size).clear()
+
+                }
+            }
+
             null -> backStack.removeLastOrNull()
         }
     }
@@ -104,4 +113,5 @@ sealed interface PopUpTo {
 
     data class Class(val clazz: KClass<out LbcDestination<*>>, override val inclusive: Boolean = false) : PopUpTo
     data class Instance(val destination: LbcDestination<*>, override val inclusive: Boolean = false) : PopUpTo
+    data class Root(override val inclusive: Boolean = true) : PopUpTo
 }

--- a/compose/navigation/src/main/kotlin/studio/lunabee/compose/navigation/NavigationHelper.kt
+++ b/compose/navigation/src/main/kotlin/studio/lunabee/compose/navigation/NavigationHelper.kt
@@ -54,7 +54,6 @@ class NavigationHelper(
                     backStack.clear()
                 } else {
                     backStack.subList(1, backStack.size).clear()
-
                 }
             }
 


### PR DESCRIPTION
## 📜 Description

Add Root option to popupTo for Navigation library

## 💡 Motivation and Context

Allow to clear the backstack up until the first destination

## 💚 How did you test it?

## 📝 Checklist
* [ ] I reviewed the submitted code
* [ ] I launched `./gradlew detekt`
* [ ] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
