### PR TITLE
Forward @Provided onto generated reducer factory params

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -198,6 +198,19 @@ artifact (`com.github.parse-community.Parse-SDK-Android:coroutines`) instead of 
 only transitively inside the Parse SDK. LiveQuery subscription, reconnect and the synchronize-on-create/update trigger are
 behaviorally unchanged.
 
+## 2026-06-12
+
+```
+LbcpresenterKsp 2.0.0-rc04
+LbcpresenterKoinKsp 2.0.0-rc04
+```
+
+- Forward `@org.koin.core.annotation.Provided` from a `@GenerateReducerFactory` reducer constructor parameter onto the
+  generated reducer factory constructor parameter. Previously only Koin qualifiers (`@Named` / custom `@Qualifier`) were
+  propagated, so a `@Provided` reducer dependency was silently dropped and the `@Factory`-annotated generated factory still
+  required it in the compile-verified Koin graph. Reducer dependencies provided outside the module's compile-safety scope
+  (DSL definitions, cross-module types) can now be marked `@Provided` instead of having to be annotated.
+
 ## 2026-0610
 
 ```

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -67,7 +67,7 @@ object AndroidConfig {
     const val LBCPRESENTER_VERSION: String = "2.0.0-rc01"
     const val LBCPRESENTER_ANNOTATIONS_VERSION: String = "2.0.0-rc01"
     const val LBCPRESENTER_KOIN_VERSION: String = "2.0.0-rc01"
-    const val LBCPRESENTER_KSP_VERSION: String = "2.0.0-rc03"
+    const val LBCPRESENTER_KSP_VERSION: String = "2.0.0-rc04"
     const val LBCPRESENTER_KOIN_KSP_VERSION: String = LBCPRESENTER_KSP_VERSION
     const val LBCNAVIGATION_VERSION: String = "1.1.0"
     const val LBCROBOLECTRICTEST_VERSION: String = "1.1.0"

--- a/compose/presenter/presenter-koin-ksp/src/main/kotlin/studio/lunabee/compose/presenter/ksp/koin/KoinFactoryDecorator.kt
+++ b/compose/presenter/presenter-koin-ksp/src/main/kotlin/studio/lunabee/compose/presenter/ksp/koin/KoinFactoryDecorator.kt
@@ -25,6 +25,7 @@ import studio.lunabee.compose.presenter.ksp.ValidatedReducerParameter
 
 private val koinFactoryAnnotation: ClassName = ClassName("org.koin.core.annotation", "Factory")
 private val koinNamedAnnotation: ClassName = ClassName("org.koin.core.annotation", "Named")
+private val koinProvidedAnnotation: ClassName = ClassName("org.koin.core.annotation", "Provided")
 
 /**
  * Annotates the generated factory class with [org.koin.core.annotation.Factory] so it can be picked up by a Koin
@@ -40,10 +41,18 @@ internal object KoinFactoryDecorator : GeneratedFactoryDecorator {
         listOf(AnnotationSpec.builder(koinFactoryAnnotation).build())
 
     /**
-     * Propagates the Koin qualifier of [parameter] onto the generated factory constructor parameter.
+     * Propagates the Koin qualifier and the [org.koin.core.annotation.Provided] marker of [parameter] onto the
+     * generated factory constructor parameter, so a @Provided reducer dependency stays excluded from Koin
+     * compile-time safety on the generated factory too.
      */
     override fun parameterAnnotations(parameter: ValidatedReducerParameter): List<AnnotationSpec> =
-        listOfNotNull(qualifierAnnotation(parameter.qualifier))
+        listOfNotNull(
+            qualifierAnnotation(parameter.qualifier),
+            providedAnnotation(parameter.isProvided),
+        )
+
+    private fun providedAnnotation(isProvided: Boolean): AnnotationSpec? =
+        AnnotationSpec.builder(koinProvidedAnnotation).build().takeIf { isProvided }
 
     private fun qualifierAnnotation(qualifier: DiQualifier?): AnnotationSpec? = when (qualifier) {
         null -> null

--- a/compose/presenter/presenter-koin-ksp/src/test/kotlin/studio/lunabee/compose/presenter/ksp/koin/KoinFactoryDecoratorTest.kt
+++ b/compose/presenter/presenter-koin-ksp/src/test/kotlin/studio/lunabee/compose/presenter/ksp/koin/KoinFactoryDecoratorTest.kt
@@ -90,6 +90,14 @@ class KoinFactoryDecoratorTest {
                         hasDefault = false,
                         isVararg = false,
                     ),
+                    RawReducerParameter(
+                        name = "providedDependency",
+                        typeName = ClassName("studio.lunabee.compose.demo.presenter.timer", "TimerProvidedDependency"),
+                        hasRuntimeAnnotation = false,
+                        hasDefault = false,
+                        isVararg = false,
+                        isProvided = true,
+                    ),
                 ),
             ),
         )
@@ -100,6 +108,9 @@ class KoinFactoryDecoratorTest {
         assertTrue(generatedSource.contains("@Factory\npublic class AnnotatedTimerReducerFactory"))
         assertTrue(generatedSource.contains("@Named(\"api\")"))
         assertTrue(generatedSource.contains("@TimerQualifier"))
+        // @Provided is forwarded so the dependency stays excluded from Koin compile-time safety on the factory.
+        assertTrue(generatedSource.contains("org.koin.core.`annotation`.Provided"))
+        assertTrue(generatedSource.contains("@Provided"))
         // @FactoryArg params stay out of the injectable constructor (they live in the FactoryArgs data class).
         assertFalse(generatedSource.contains("private val `external`"))
     }

--- a/compose/presenter/presenter-ksp/src/main/kotlin/studio/lunabee/compose/presenter/ksp/ReducerFactoryModel.kt
+++ b/compose/presenter/presenter-ksp/src/main/kotlin/studio/lunabee/compose/presenter/ksp/ReducerFactoryModel.kt
@@ -49,6 +49,7 @@ data class RawReducerParameter(
     val hasDefault: Boolean,
     val isVararg: Boolean,
     val qualifier: DiQualifier? = null,
+    val isProvided: Boolean = false,
 )
 
 /**
@@ -77,6 +78,7 @@ data class ValidatedReducerParameter(
     val typeName: TypeName,
     val kind: ParameterKind,
     val qualifier: DiQualifier? = null,
+    val isProvided: Boolean = false,
 )
 
 /**
@@ -248,6 +250,7 @@ class ReducerFactorySignatureValidator {
                 typeName = parameter.typeName,
                 kind = ParameterKind.Injected,
                 qualifier = parameter.qualifier,
+                isProvided = parameter.isProvided,
             )
         }
     }

--- a/compose/presenter/presenter-ksp/src/main/kotlin/studio/lunabee/compose/presenter/ksp/ReducerSignatureParser.kt
+++ b/compose/presenter/presenter-ksp/src/main/kotlin/studio/lunabee/compose/presenter/ksp/ReducerSignatureParser.kt
@@ -47,6 +47,9 @@ private val qualifierMetaAnnotations: Set<String> = setOf(
     "javax.inject.Qualifier",
     "org.koin.core.annotation.Qualifier",
 )
+private val providedAnnotations: Set<String> = setOf(
+    "org.koin.core.annotation.Provided",
+)
 private val kotlinUnitClassName: ClassName = ClassName("kotlin", "Unit")
 private const val SingleReducerQualifiedName = "studio.lunabee.compose.presenter.LBSingleReducer"
 
@@ -97,6 +100,7 @@ class ReducerSignatureParser {
                     hasDefault = parameter.hasDefault,
                     isVararg = parameter.isVararg,
                     qualifier = parameter.toDiQualifier(),
+                    isProvided = parameter.isProvided(),
                 )
             },
         )
@@ -115,6 +119,11 @@ class ReducerSignatureParser {
         Modifier.INTERNAL in modifiers -> Visibility.Internal
         else -> Visibility.Public
     }
+
+    private fun KSValueParameter.isProvided(): Boolean =
+        annotations.any { annotation ->
+            annotation.annotationType.resolve().declaration.qualifiedName?.asString() in providedAnnotations
+        }
 
     private fun KSValueParameter.toDiQualifier(): DiQualifier? {
         val qualifiers = annotations.mapNotNull { it.toDiQualifier() }.toList()


### PR DESCRIPTION
## What

The `lbcpresenter-koin-ksp` factory decorator forwarded Koin qualifiers (`@Named` / custom `@Qualifier`) from a `@GenerateReducerFactory` reducer constructor onto the generated factory constructor, but **dropped `@org.koin.core.annotation.Provided`**.

Because the generated factory is itself `@Factory`-annotated and joins the compile-verified Koin graph (`compileSafety = true`), a `@Provided` on the reducer was dead weight: the factory still required the dependency in the verified graph. The only workaround was to *annotate* the dependency (and add the Koin compiler to its module), even when it's a DSL definition or a cross-module type that should just be marked external.

## Change

- `ReducerSignatureParser` — detect `org.koin.core.annotation.Provided` on injected reducer params → `isProvided`
- `ReducerFactoryModel` — carry `isProvided` on `RawReducerParameter` / `ValidatedReducerParameter`
- `KoinFactoryDecorator` — emit `@Provided` on the generated factory constructor param, alongside the existing qualifier forwarding
- `KoinFactoryDecoratorTest` — assert a `@Provided` injected param is forwarded
- Bump `LbcpresenterKsp` / `LbcpresenterKoinKsp` → `2.0.0-rc04` + CHANGELOG

## Effect

Reducer dependencies provided outside the module's compile-safety scope (DSL definitions, cross-module types) can now be marked `@Provided` instead of having to be annotated — mirroring how `@Provided` already works on hand-written definitions. Qualifier-free behaviour and `@FactoryArg` handling are unchanged.

## Test

`:compose:presenter-ksp:test` + `:compose:presenter-koin-ksp:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)