### PR TITLE
feature/fix-load-heavy-drawable

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres    
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2026-06-16
+
+```
+LbcImage 1.9.1
+```
+
+Load `LbcImageSpec.ImageDrawable` through Coil so the drawable is downsampled to the layout size instead of decoding
+the full bitmap into memory, fixing high memory usage on heavy drawables.
+
 ## 2026-0610
 
 ```

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -59,7 +59,7 @@ object AndroidConfig {
     const val LBCUIFIELD_PHONEPICKER_VERSION: String = LBCUIFIELD_CORE_VERSION
     const val LBCUIFIELD_COUNTRYPICKER_VERSION: String = LBCUIFIELD_CORE_VERSION
     const val LBCUIFIELD_FORM_VERSION: String = "0.9.0"
-    const val LBCIMAGE_VERSION: String = "1.9.0"
+    const val LBCIMAGE_VERSION: String = "1.9.1"
     const val LBCGLANCE_VERSION: String = "1.6.0"
     const val LBCPRESENTER_VERSION: String = "2.0.0-rc01"
     const val LBCPRESENTER_ANNOTATIONS_VERSION: String = "2.0.0-rc01"

--- a/compose/image/src/main/kotlin/studio/lunabee/compose/image/LbcImage.kt
+++ b/compose/image/src/main/kotlin/studio/lunabee/compose/image/LbcImage.kt
@@ -34,8 +34,6 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.core.content.res.ResourcesCompat
-import androidx.core.graphics.drawable.toBitmap
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.decode.SvgDecoder
@@ -252,30 +250,32 @@ private fun DrawableImage(
     onState: ((AsyncImagePainter.State) -> Unit)?,
     errorPainter: Painter?,
 ) {
-    if (imageSpec.uiMode == Configuration.UI_MODE_TYPE_UNDEFINED) {
-        Image(
-            painter = painterResource(id = imageSpec.drawableRes),
-            contentDescription = contentDescription?.string,
-            modifier = modifier,
-            contentScale = contentScale,
-            alignment = alignment,
-            colorFilter = colorFilter,
-        )
-    } else {
-        val configuration = Configuration().apply {
-            uiMode = imageSpec.uiMode
+    val context = LocalContext.current
+    // Resolve the drawable through a configuration context so Coil picks the right uiMode (day/night) variant.
+    val requestContext = remember(context, imageSpec.uiMode) {
+        if (imageSpec.uiMode == Configuration.UI_MODE_TYPE_UNDEFINED) {
+            context
+        } else {
+            val configuration = Configuration().apply {
+                uiMode = imageSpec.uiMode
+            }
+            context.createConfigurationContext(configuration)
         }
-        val resources = LocalContext.current.createConfigurationContext(configuration).resources
-        val bitmap = ResourcesCompat.getDrawable(resources, imageSpec.drawableRes, null)!!.toBitmap()
-        LbcImage(
-            imageSpec = LbcImageSpec.Bitmap(bitmap),
-            modifier = modifier,
-            contentDescription = contentDescription,
-            onState = onState,
-            contentScale = contentScale,
-            alignment = alignment,
-            colorFilter = colorFilter,
-            errorPainter = errorPainter,
-        )
     }
+    // Let Coil load the drawable: it downsamples to the layout size instead of decoding the full bitmap.
+    AsyncImage(
+        model = ImageRequest
+            .Builder(requestContext)
+            .data(imageSpec.drawableRes)
+            .build(),
+        contentDescription = contentDescription?.string,
+        modifier = modifier,
+        alignment = alignment,
+        contentScale = contentScale,
+        error = errorPainter,
+        onError = onState,
+        onLoading = onState,
+        onSuccess = onState,
+        colorFilter = colorFilter,
+    )
 }


### PR DESCRIPTION
## What

`LbcImageSpec.ImageDrawable` now loads through Coil `AsyncImage` instead of decoding the full-resolution bitmap.

- **Before:** the `uiMode` branch did `ResourcesCompat.getDrawable(...).toBitmap()` — decoded the full bitmap into memory; the default branch used `painterResource` (also no downsampling).
- **After:** both paths go through Coil, which downsamples to the composable's layout size. Day/night (`uiMode`) is preserved by building the `ImageRequest` with a `createConfigurationContext`.
- Bonus: `onState` (loading/error/success) now actually fires for drawables.

Removed dead imports (`ResourcesCompat`, `toBitmap`).

## Release

- `LbcImage` 1.9.0 → 1.9.1 (patch / bugfix)
- `CHANGELOG.MD` entry added

## Note

Behavior shift: drawables now load asynchronously (one placeholder frame) instead of synchronously. Expected trade-off for the memory fix.

## Verification

- `./gradlew detekt -Pstudio.lunabee.detekt.skipDependencySorting` ✅
- `./gradlew :compose:image:assembleDebug` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)