### PR TITLE
test: stabilise flaky ShowDelayedLoading hide-before-delay test

### DIFF
--- a/common/core/core-compose/src/androidTest/kotlin/studio/lunabee/core/helper/ShowDelayedLoadingTest.kt
+++ b/common/core/core-compose/src/androidTest/kotlin/studio/lunabee/core/helper/ShowDelayedLoadingTest.kt
@@ -157,18 +157,19 @@ class ShowDelayedLoadingTest {
             actualShowLoading.add(showLoading)
         }
 
-        // False because delay
-        assertFalse(actualShowLoading.last())
-        composeTestRule.wait(delayBeforeShow / 2)
+        // Hidden initially because of the show delay
         assertFalse(actualShowLoading.last())
 
-        // Request false
+        // Request hide before the show delay can elapse: this cancels the pending show
         shouldShowLoading.value = false
         composeTestRule.mainClock.advanceTimeByFrame()
         assertFalse(actualShowLoading.last())
 
-        // Assert showLoading was never true
-        composeTestRule.wait(delayBeforeShow / 2)
+        // Wait well beyond the show delay; the cancelled show must never become visible.
+        // Asserting after the full delay has elapsed (instead of relying on a wall-clock
+        // window shorter than delayBeforeShow) removes the timing race that made this test
+        // flaky on loaded CI agents, where the real wait could overshoot delayBeforeShow.
+        composeTestRule.wait(delayBeforeShow * 2)
         assertFalse(actualShowLoading.any { it })
     }
 }


### PR DESCRIPTION
## Flaky tests found

- `studio.lunabee.core.helper.ShowDelayedLoadingTest.rememberShowDelayedLoading_hide_before_delay_test` (instrumented, `common/core/core-compose`)
  - Failed intermittently across **unrelated** PRs (`pull/307/merge` #696, `pull/314/merge` #692/#693) — none touched the test or its code; `pull/314` then went green (#694) with no change → **flaky**, not a regression. High flake rate.
  - Root cause: the test asserted loading was *still hidden* after a real wall-clock wait of `delayBeforeShow / 2` (100 ms). The delegate (`LBLoadingVisibilityDelayDelegate`) schedules the show via `delay(delayBeforeShow)` on the real `Dispatchers.Main` (the compose `mainClock` does **not** drive a kotlinx `delay`). On loaded CI agents the real `delay(100 ms)` on `Dispatchers.IO` could overshoot the 200 ms show delay, so the show coroutine fired and flipped state to `true` before the assertion ran → `AssertionError: Expected value to be false` at `ShowDelayedLoadingTest.kt:163`.

## Fixes

- `test: stabilise flaky rememberShowDelayedLoading hide-before-delay test` — stop asserting a time-bounded negative. Request the hide *before* the show delay can elapse (still exercising the pending-show cancellation path in the delegate), then settle well past `delayBeforeShow` and assert the loading never became visible. The assertion only strengthens with longer waits, so the wall-clock race is gone. Test-only change; no product code or public API touched, so no module version bump / CHANGELOG entry.

## CI verification

5 consecutive green PullRequest builds on `pull/315/merge` (resets on any red — none occurred):

1. [#697 — 41014](https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_PullRequest/41014)
2. [#698 — 41018](https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_PullRequest/41018)
3. [#699 — 41022](https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_PullRequest/41022)
4. [#700 — 41023](https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_PullRequest/41023)
5. [#701 — 41025](https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_PullRequest/41025)

🤖 Generated with [Claude Code](https://claude.com/claude-code)