### PR TITLE
feat: add enumValueOfOrElse to extension module

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -8,6 +8,6 @@
   </component>
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.3.20" />
+    <option name="version" value="2.3.21" />
   </component>
 </project>

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres    
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2026-06-26
+
+```
+Lbextensions 4.11.0
+bom 4.14.0
+```
+
+- Add `enumValueOfOrElse` to the `extension` module: resolves an enum entry by name and returns a caller-provided
+  `fallback` instead of `null` when the name is missing or unknown.
+
 ## 2026-06-16
 
 ```

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -70,11 +70,11 @@ object AndroidConfig {
     const val LBCROBOLECTRICTEST_VERSION: String = "1.1.0"
     const val LOGGER_KERMIT_VERSION: String = "4.10.0"
     const val CORE_VERSION: String = "4.11.0"
-    const val EXTENSIONS_VERSION: String = "4.10.0"
+    const val EXTENSIONS_VERSION: String = "4.11.0"
     const val TEST_VERSION: String = "4.9.0"
     const val KTOR_VERSION: String = "4.10.0"
     const val LOADING_VERSION: String = "4.10.0"
-    const val PLATFORM_VERSION: String = "4.13.0"
+    const val PLATFORM_VERSION: String = "4.14.0"
     const val EXTENSIONS_ANDROID_VERSION: String = "4.9.0"
     const val MONITORING_CORE_VERSION: String = "4.9.1"
     const val MONITORING_KTOR_VERSION: String = MONITORING_CORE_VERSION

--- a/common/extension/extension/src/commonMain/kotlin/studio/lunabee/extension/EnumExt.kt
+++ b/common/extension/extension/src/commonMain/kotlin/studio/lunabee/extension/EnumExt.kt
@@ -26,6 +26,12 @@ inline fun <reified T : Enum<T>> enumValueOfOrNull(name: String?, logger: Logger
     null
 }
 
+inline fun <reified T : Enum<T>> enumValueOfOrElse(name: String?, fallback: T): T = try {
+    name?.let { enumValueOf<T>(it) }
+} catch (_: IllegalArgumentException) {
+    null
+} ?: fallback
+
 object EnumExt {
     val enumLogger: Logger = LBLogger.get("EnumExt")
 }


### PR DESCRIPTION
## Summary

- Add `enumValueOfOrElse(name, fallback)` to the `extension` KMP module — resolves an enum entry by name, returns a caller-provided `fallback` instead of `null` when the name is missing or unknown (complements existing `enumValueOfOrNull`).
- Bump `extension` 4.10.0 → 4.11.0.
- Bump `bom` 4.13.0 → 4.14.0 (transitive: pins `extension`).
- CHANGELOG entry for 2026-06-26.

## Test plan

- `./gradlew detekt -Pstudio.lunabee.detekt.skipDependencySorting` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)