### PR TITLE
feature/blocking-view-modifier

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ```
 Lbloading 4.10.1
+bom 4.14.1
 ```
 
 - Add a `modifier` parameter to `DefaultBlockingContent` so callers can customize the blocking view.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres    
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2026-07-03
+
+```
+Lbloading 4.10.1
+```
+
+- Add a `modifier` parameter to `DefaultBlockingContent` so callers can customize the blocking view.
+
 ## 2026-06-26
 
 ```

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -73,7 +73,7 @@ object AndroidConfig {
     const val EXTENSIONS_VERSION: String = "4.11.0"
     const val TEST_VERSION: String = "4.9.0"
     const val KTOR_VERSION: String = "4.10.0"
-    const val LOADING_VERSION: String = "4.10.0"
+    const val LOADING_VERSION: String = "4.10.1"
     const val PLATFORM_VERSION: String = "4.14.0"
     const val EXTENSIONS_ANDROID_VERSION: String = "4.9.0"
     const val MONITORING_CORE_VERSION: String = "4.9.1"

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -74,7 +74,7 @@ object AndroidConfig {
     const val TEST_VERSION: String = "4.9.0"
     const val KTOR_VERSION: String = "4.10.0"
     const val LOADING_VERSION: String = "4.10.1"
-    const val PLATFORM_VERSION: String = "4.14.0"
+    const val PLATFORM_VERSION: String = "4.14.1"
     const val EXTENSIONS_ANDROID_VERSION: String = "4.9.0"
     const val MONITORING_CORE_VERSION: String = "4.9.1"
     const val MONITORING_KTOR_VERSION: String = MONITORING_CORE_VERSION

--- a/common/loading/loading-compose/src/main/kotlin/studio/lunabee/loading/LoadingView.kt
+++ b/common/loading/loading-compose/src/main/kotlin/studio/lunabee/loading/LoadingView.kt
@@ -128,7 +128,8 @@ fun DefaultLoadingContent(
                     liveRegion = LiveRegionMode.Polite
                     this.contentDescription = loadingContentDescription
                 }
-            }.then(modifier)
+            }
+            .then(modifier)
             .drawBehind { drawRect(background) },
     ) {
         progressIndicator()
@@ -141,9 +142,11 @@ fun DefaultLoadingContent(
 @OptIn(ExperimentalComposeUiApi::class)
 @Suppress("UnusedReceiverParameter")
 @Composable
-fun BlockingViewScope.DefaultBlockingContent() {
+fun BlockingViewScope.DefaultBlockingContent(
+    modifier: Modifier = Modifier,
+) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .clickable(onClick = {}, enabled = false)
             .semantics {


### PR DESCRIPTION
## 📜 Description

- Add `modifier` param to DefaultBlockingContent

## 💡 Motivation and Context

- Good practice + allow to use `matchParentSize` when wrapped in a box

## 💚 How did you test it?

- Maven local in client project (IDF)

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
