### PR TITLE
fix/sync-non-incremental-cursor

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres    
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2026-07-06
+
+```
+Synchronization 2.0.0-beta02
+Synchronization Parse-Room 2.0.0-beta02
+```
+
+- Fix `LBSyncManager`: on a successful download the server `updatedAt` cursor is now persisted on terminal
+  success for **every** manager, not only when `supportIncrementalSync()` is enabled. This restores the legacy
+  `lbsynchronization` behaviour, where `supportIncrementalSync()` gates only per-page checkpointing (so a
+  mid-paging failure can resume), not whether the following run filters by the cursor. Without the fix a
+  non-incremental manager re-downloaded its full data set on every sync instead of only the records changed
+  since the last run.
+
 ## 2026-06-26
 
 ```

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -81,8 +81,8 @@ object AndroidConfig {
     const val MONITORING_OKHTTP_VERSION: String = MONITORING_CORE_VERSION
     const val MONITORING_ROOM_VERSION: String = MONITORING_CORE_VERSION
     const val MONITORING_UI_VERSION: String = MONITORING_CORE_VERSION
-    const val SYNCHRONIZATION_VERSION: String = "2.0.0-beta01"
-    const val SYNCHRONIZATION_PARSE_ROOM_VERSION: String = "2.0.0-beta01"
+    const val SYNCHRONIZATION_VERSION: String = "2.0.0-beta02"
+    const val SYNCHRONIZATION_PARSE_ROOM_VERSION: String = "2.0.0-beta02"
 
     val JDK_VERSION: JavaVersion = JavaVersion.VERSION_21
     val JVM_TARGET: JvmTarget = JvmTarget.JVM_21

--- a/common/synchronization/synchronization/src/androidHostTest/kotlin/studio/lunabee/synchronization/syncmanager/DownloadTest.kt
+++ b/common/synchronization/synchronization/src/androidHostTest/kotlin/studio/lunabee/synchronization/syncmanager/DownloadTest.kt
@@ -30,7 +30,7 @@ import kotlin.time.Instant
 /**
  * Download-side engine behaviour: the ascending cursor, `sinceLastDate` seeding, paging cursor
  * threading, the `hasNextPage` decision (pageInfo override vs `queryPageSize` fallback), and terminal
- * local-date persistence. Asserts observable behaviour only (persisted cursor, captured fetch args,
+ * cursor + local-date persistence. Asserts observable behaviour only (persisted cursor, captured fetch args,
  * status sequence) — never private fields.
  */
 class DownloadTest {
@@ -250,14 +250,15 @@ class DownloadTest {
 
     // endregion
 
-    // region terminal local-date persistence
+    // region terminal cursor & local-date persistence
 
     @Test
-    fun local_sync_date_is_persisted_on_terminal_success_even_without_incremental() = runManagerTest { store, scope ->
+    fun terminal_success_persists_both_local_date_and_server_cursor_even_without_incremental() = runManagerTest { store, scope ->
+        val serverMax = Instant.fromEpochMilliseconds(9_000L)
         val manager = FakeSyncManager(
             store = store,
             scope = scope,
-            pages = listOf(FetchPage<ServerObj, Int>(objects = listOf(ServerObj(updatedAt = Instant.fromEpochMilliseconds(9_000L))))),
+            pages = listOf(FetchPage<ServerObj, Int>(objects = listOf(ServerObj(updatedAt = serverMax)))),
             supportIncremental = false,
             supportChangeNotification = true,
         )
@@ -270,9 +271,10 @@ class DownloadTest {
             manager.lastSuccessfulSyncDate() != null,
             "the local sync date is always persisted on terminal download success",
         )
-        assertNull(
-            store.lastServerSyncDate(syncKey = manager.syncKey),
-            "the server cursor stays null when incremental sync is off",
+        assertEquals(
+            expected = serverMax.toEpochMilliseconds(),
+            actual = store.lastServerSyncDate(syncKey = manager.syncKey),
+            "the server cursor is also persisted on terminal success, even with incremental sync off (legacy parity)",
         )
     }
 

--- a/common/synchronization/synchronization/src/androidHostTest/kotlin/studio/lunabee/synchronization/syncmanager/LBSyncManagerTest.kt
+++ b/common/synchronization/synchronization/src/androidHostTest/kotlin/studio/lunabee/synchronization/syncmanager/LBSyncManagerTest.kt
@@ -111,19 +111,66 @@ class LBSyncManagerTest {
     }
 
     @Test
-    fun incremental_cursor_is_not_saved_when_incremental_sync_is_unsupported() = runManagerTest { store, scope ->
+    fun terminal_success_persists_the_server_cursor_even_without_incremental_sync() = runManagerTest { store, scope ->
+        val maxDate = Instant.fromEpochMilliseconds(5_000L)
         val manager = FakeSyncManager(
             store = store,
             scope = scope,
-            pages = listOf(FetchPage<ServerObj, Int>(objects = listOf(ServerObj(updatedAt = Instant.fromEpochMilliseconds(5_000L))))),
+            pages = listOf(FetchPage<ServerObj, Int>(objects = listOf(ServerObj(updatedAt = maxDate)))),
             supportIncremental = false,
         )
 
         manager.synchronize()
 
+        assertEquals(
+            expected = maxDate.toEpochMilliseconds(),
+            actual = store.lastServerSyncDate(syncKey = manager.syncKey),
+            "a successful download persists the server cursor for legacy parity, even without incremental sync",
+        )
+    }
+
+    @Test
+    fun incremental_sync_checkpoints_a_completed_page_cursor_when_a_later_page_fails() = runManagerTest { store, scope ->
+        // Page 0 is a full page (so paging continues), then page 1 throws mid-download.
+        val page0Max = Instant.fromEpochMilliseconds(100L)
+        val manager = FakeSyncManager(
+            store = store,
+            scope = scope,
+            pages = listOf(FetchPage<ServerObj, Int>(objects = listOf(ServerObj(updatedAt = page0Max)))),
+            pageSize = 1,
+            fetchErrorOnPage = 1,
+            supportIncremental = true,
+        )
+
+        val result = manager.synchronize()
+
+        assertTrue(result is LBResult.Failure, "a mid-paging fetch failure surfaces as Failure")
+        assertEquals(
+            expected = page0Max.toEpochMilliseconds(),
+            actual = store.lastServerSyncDate(syncKey = manager.syncKey),
+            "incremental sync checkpoints the completed page's cursor so the next run resumes from it",
+        )
+    }
+
+    @Test
+    fun non_incremental_sync_persists_no_cursor_when_a_later_page_fails() = runManagerTest { store, scope ->
+        // Same shape, but non-incremental: nothing is checkpointed per page and the failure aborts before
+        // the terminal save, so no cursor is persisted.
+        val manager = FakeSyncManager(
+            store = store,
+            scope = scope,
+            pages = listOf(FetchPage<ServerObj, Int>(objects = listOf(ServerObj(updatedAt = Instant.fromEpochMilliseconds(100L))))),
+            pageSize = 1,
+            fetchErrorOnPage = 1,
+            supportIncremental = false,
+        )
+
+        val result = manager.synchronize()
+
+        assertTrue(result is LBResult.Failure, "a mid-paging fetch failure surfaces as Failure")
         assertNull(
             store.lastServerSyncDate(syncKey = manager.syncKey),
-            "no server cursor is persisted without incremental sync",
+            "without per-page checkpointing a failed multi-page download persists no cursor",
         )
     }
 

--- a/common/synchronization/synchronization/src/androidHostTest/kotlin/studio/lunabee/synchronization/testfixture/SyncTestFixture.kt
+++ b/common/synchronization/synchronization/src/androidHostTest/kotlin/studio/lunabee/synchronization/testfixture/SyncTestFixture.kt
@@ -69,7 +69,8 @@ internal data class FetchArgs(val page: Int, val cursor: String?, val sinceLastD
  * Fake SPI subclass exercising the observable engine surface only.
  *
  * Superset of every per-test knob the engine tests need:
- * - download shape: [pages], [pageSize], [hasNextPageOverride] ([pageInfo]-driven), [fetchError];
+ * - download shape: [pages], [pageSize], [hasNextPageOverride] ([pageInfo]-driven), [fetchError],
+ *   [fetchErrorOnPage] (throw only when fetching the Nth page);
  * - upload shape: [uploadObjects], [pushError], [pushErrorOnAttempt] (throw only on the Nth push);
  * - incremental/notification gates: [supportIncremental], [supportChangeNotification];
  * - concurrency probes: [fetchGate], [gateOnlyFirstFetch];
@@ -88,6 +89,7 @@ internal open class FakeSyncManager(
     private val supportIncremental: Boolean = false,
     private val pageSize: Int? = null,
     private val fetchError: Exception? = null,
+    private val fetchErrorOnPage: Int? = null,
     private val pushError: Exception? = null,
     private val pushErrorOnAttempt: Int? = null,
     private val fetchGate: CompletableDeferred<Unit>? = null,
@@ -127,6 +129,7 @@ internal open class FakeSyncManager(
             fetchGate.await()
         }
         fetchError?.let { throw it }
+        fetchErrorOnPage?.let { if (page == it) throw FetchPageException(page = it) }
         return pages.getOrElse(page) { FetchPage(objects = emptyList()) }
     }
 
@@ -176,6 +179,9 @@ internal open class FakeSyncManager(
 
 /** Thrown by [FakeSyncManager] when [FakeSyncManager.pushErrorOnAttempt] fires on a given push attempt. */
 internal class PushAttemptException(attempt: Int) : Exception("push failed on attempt $attempt")
+
+/** Thrown by [FakeSyncManager] when [FakeSyncManager.fetchErrorOnPage] fires on a given page fetch. */
+internal class FetchPageException(page: Int) : Exception("fetch failed on page $page")
 
 /** Thrown by [StatefulFakeSyncManager.failNextPush] to model a one-shot transient push failure. */
 internal class TransientPushException : Exception("transient push failure")

--- a/common/synchronization/synchronization/src/androidMain/kotlin/studio/lunabee/synchronization/syncmanager/LBSyncManager.kt
+++ b/common/synchronization/synchronization/src/androidMain/kotlin/studio/lunabee/synchronization/syncmanager/LBSyncManager.kt
@@ -364,8 +364,14 @@ abstract class LBSyncManager<ServerData, LocalData, PageInfo>(
     /**
      * Downloads every page from the server. Status transitions `DownloadStarted` →
      * `DownloadUpdated` (per page) → `DownloadFinishSuccessfully`; a fetch failure maps to
-     * `DownloadFinishWithError` and rethrows. The incremental cursor is saved per page only when
-     * [supportIncrementalSync]; the local sync date is always saved on terminal success (parity).
+     * `DownloadFinishWithError` and rethrows.
+     *
+     * Cursor persistence mirrors the legacy engine: the server cursor is checkpointed **per page**
+     * only when [supportIncrementalSync] (so a mid-paging failure can resume from the last saved
+     * page), and is **always** persisted together with the local sync date on terminal success —
+     * even for a non-incremental manager, whose next run then fetches only records newer than that
+     * cursor. [supportIncrementalSync] therefore governs mid-paging resumption, not whether the
+     * cursor filter applies on the following run.
      */
     private suspend fun download() {
         setStatusInternal(LBSyncProcessStatus.DownloadStarted(Clock.System.now()))
@@ -406,9 +412,9 @@ abstract class LBSyncManager<ServerData, LocalData, PageInfo>(
         }
 
         setStatusInternal(LBSyncProcessStatus.DownloadFinishSuccessfully(Clock.System.now()))
-        // Terminal save always records the local sync date; the server cursor is only persisted for
-        // incremental sync (the next run resumes from it).
-        saveDownloadDate(if (supportIncrementalSync()) maxDate else null)
+        // Terminal success always records both the local sync date and the server cursor (legacy
+        // parity); the per-page checkpoint above is the only part gated on incremental sync.
+        saveDownloadDate(maxDate)
     }
 
     /**


### PR DESCRIPTION
## Problem

`LBSyncManager.download()` persisted the server `updatedAt` cursor on terminal success **only** when `supportIncrementalSync()` was enabled:

```kotlin
saveDownloadDate(if (supportIncrementalSync()) maxDate else null)
```

A non-incremental manager therefore never stored a cursor, so its next run had no `sinceLastDate` and re-downloaded the **full** data set every sync (paged, but complete) instead of only the records changed since the last run.

This diverges from the legacy `lbsynchronization` engine (Libraries_Android @ `b19dc13`), whose `fetchCompletion` saved the cursor **unconditionally** on success — `supportIncrementalSync()` there gates only the *per-page* checkpoint, not the cursor filter itself.

## Fix

- Terminal success now always persists the server cursor (`saveDownloadDate(maxDate)`), matching the legacy contract.
- Per-page checkpointing stays gated on `supportIncrementalSync()` — its real purpose: letting a mid-paging failure resume from the last completed page.
- Semantics restored: `supportIncrementalSync()` governs mid-paging resumption, **not** whether the following run filters by the cursor.

## Tests (`:synchronization:testHostTest`, 78 green)

- `DownloadTest`: `terminal_success_persists_both_local_date_and_server_cursor_even_without_incremental` (flipped from asserting the cursor stays null).
- `LBSyncManagerTest`: replaced `incremental_cursor_is_not_saved_when_incremental_sync_is_unsupported` with `terminal_success_persists_the_server_cursor_even_without_incremental_sync`; added `incremental_sync_checkpoints_a_completed_page_cursor_when_a_later_page_fails` and `non_incremental_sync_persists_no_cursor_when_a_later_page_fails` to pin the per-page-checkpoint distinction.
- Fixture: added `fetchErrorOnPage` knob to `FakeSyncManager` to model a mid-paging fetch failure.

## Release

- `SYNCHRONIZATION_VERSION` / `SYNCHRONIZATION_PARSE_ROOM_VERSION` → `2.0.0-beta02`; CHANGELOG updated.

## Downstream

RunMotion's Parse↔Room migration relies on this parity — its non-incremental `UserWorkout` / `UserWorkoutDone` managers must fetch deltas, not full re-downloads, once past the first sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

