### PR TITLE
fix: stabilise flaky ShowDelayedLoading show-after-delay test

### DIFF
--- a/common/core/core-compose/src/androidTest/kotlin/studio/lunabee/core/helper/ShowDelayedLoadingTest.kt
+++ b/common/core/core-compose/src/androidTest/kotlin/studio/lunabee/core/helper/ShowDelayedLoadingTest.kt
@@ -31,13 +31,20 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class ShowDelayedLoadingTest {
 
     @get:Rule
     val composeTestRule: ComposeContentTestRule = createComposeRule()
+
+    /**
+     * [LBLoadingVisibilityDelayDelegate] schedules on [kotlinx.coroutines.Dispatchers.Main] in real
+     * time, not on the Compose test clock, so every delay asserted here must dwarf composition and
+     * frame work — a short one races with a loaded CI agent. Exact timing is covered deterministically
+     * by `LBLoadingVisibilityDelayDelegateTest` with a virtual-time dispatcher.
+     */
+    private val testDelay: Duration = 2.seconds
 
     @Test
     fun rememberShowDelayedLoading_no_loading_test() {
@@ -76,9 +83,7 @@ class ShowDelayedLoadingTest {
     @Test
     fun rememberShowDelayedLoading_show_after_delay_test() {
         var actualShowLoading: Boolean? = null
-        // The pending show elapses on real time (Dispatchers.Main), so the delay must outlast the
-        // composition itself, which can take a few hundred ms on a loaded CI agent.
-        val delayBeforeShow = 2.seconds
+        val delayBeforeShow = testDelay
 
         composeTestRule.setContent {
             val showLoading: Boolean by rememberShowDelayedLoading(
@@ -115,10 +120,10 @@ class ShowDelayedLoadingTest {
     }
 
     @Test
-    fun rememberShowDelayedLoading_hide_min_loading_test(): TestResult = runTest {
+    fun rememberShowDelayedLoading_hide_min_loading_test() {
         var actualShowLoading: Boolean? = null
         val shouldShowLoading = mutableStateOf(true)
-        val minLoadingShowDuration = 100.milliseconds
+        val minLoadingShowDuration = testDelay
 
         composeTestRule.setContent {
             val showLoading: Boolean by rememberShowDelayedLoading(
@@ -138,15 +143,14 @@ class ShowDelayedLoadingTest {
         composeTestRule.mainClock.advanceTimeByFrame()
         assertTrue(actualShowLoading) // Still true because of minLoadingShowDuration
 
-        composeTestRule.wait(minLoadingShowDuration)
-        assertFalse(actualShowLoading)
+        composeTestRule.waitUntil(timeoutMillis = (minLoadingShowDuration * 3).inWholeMilliseconds) { actualShowLoading == false }
     }
 
     @Test
     fun rememberShowDelayedLoading_hide_before_delay_test(): TestResult = runTest {
         val actualShowLoading = mutableListOf<Boolean>()
         val shouldShowLoading = mutableStateOf(true)
-        val delayBeforeShow = 200.milliseconds
+        val delayBeforeShow = testDelay
         val minLoadingShowDuration = Duration.INFINITE
 
         composeTestRule.setContent {
@@ -167,11 +171,8 @@ class ShowDelayedLoadingTest {
         composeTestRule.mainClock.advanceTimeByFrame()
         assertFalse(actualShowLoading.last())
 
-        // Wait well beyond the show delay; the cancelled show must never become visible.
-        // Asserting after the full delay has elapsed (instead of relying on a wall-clock
-        // window shorter than delayBeforeShow) removes the timing race that made this test
-        // flaky on loaded CI agents, where the real wait could overshoot delayBeforeShow.
-        composeTestRule.wait(delayBeforeShow * 2)
+        // Wait well beyond the show delay; the cancelled show must never become visible
+        composeTestRule.wait(delayBeforeShow * 1.5)
         assertFalse(actualShowLoading.any { it })
     }
 }

--- a/common/core/core-compose/src/androidTest/kotlin/studio/lunabee/core/helper/ShowDelayedLoadingTest.kt
+++ b/common/core/core-compose/src/androidTest/kotlin/studio/lunabee/core/helper/ShowDelayedLoadingTest.kt
@@ -32,6 +32,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class ShowDelayedLoadingTest {
 
@@ -73,9 +74,11 @@ class ShowDelayedLoadingTest {
     }
 
     @Test
-    fun rememberShowDelayedLoading_show_after_delay_test(): TestResult = runTest {
+    fun rememberShowDelayedLoading_show_after_delay_test() {
         var actualShowLoading: Boolean? = null
-        val delayBeforeShow = 100.milliseconds
+        // The pending show elapses on real time (Dispatchers.Main), so the delay must outlast the
+        // composition itself, which can take a few hundred ms on a loaded CI agent.
+        val delayBeforeShow = 2.seconds
 
         composeTestRule.setContent {
             val showLoading: Boolean by rememberShowDelayedLoading(
@@ -88,8 +91,7 @@ class ShowDelayedLoadingTest {
         }
 
         assertFalse(actualShowLoading!!)
-        composeTestRule.wait(delayBeforeShow * 1.5)
-        assertTrue(actualShowLoading)
+        composeTestRule.waitUntil(timeoutMillis = (delayBeforeShow * 3).inWholeMilliseconds) { actualShowLoading == true }
     }
 
     @Test


### PR DESCRIPTION
## Flaky tests found

Both failures are in `studio.lunabee.core.helper.ShowDelayedLoadingTest` (instrumented, `core-compose`) and share **one root cause**: `LBLoadingVisibilityDelayDelegate` schedules its show/hide with `delay(...)` on `Dispatchers.Main`, i.e. **real time**, not the Compose test clock. Each test then asserted state inside a wall-clock window (100–200 ms) shorter than composition itself takes on a loaded CI agent, so the pending show fired before the assertion ran.

| Test | Frequency | Classification |
|---|---|---|
| `rememberShowDelayedLoading_show_after_delay_test` | **15 of the last 125** runs, across `pull/300, 301, 303, 306, 307, 308, 310, 326, 330` — none of which touched this code; same commit passed (#758) and failed (#761, #769) | flaky |
| `rememberShowDelayedLoading_hide_before_delay_test` | surfaced by this PR's own gauntlet (#775) on the *first* assertion after `setContent`; 13 earlier failures up to #711 | flaky |

Both failed as `java.lang.AssertionError: Expected value to be false.`. #315 had partially fixed `hide_before_delay` by stretching its *later* wait, but left its initial 200 ms window intact — that is what #775 hit.

No deterministic failures, no infra reds encountered.

## Fixes

- **`b29e950`** `test: stabilise flaky rememberShowDelayedLoading show-after-delay test` — `show_after_delay`: `delayBeforeShow` 100 ms → 2 s, and the fixed `wait(delayBeforeShow * 1.5)` replaced by a `waitUntil` poll, removing the race on both sides.
- **`138bc2c`** `test: widen every real-time window in ShowDelayedLoadingTest` — hoists one class-level `testDelay = 2.seconds` used by all three timing-sensitive tests, so no magic per-test window remains. `hide_before_delay` 200 ms → `testDelay`; `hide_min_loading` 100 ms → `testDelay` plus a `waitUntil` poll (same race, latent: 0/125 failures, hardened so it cannot reset a future streak). KDoc on `testDelay` records why the windows must be generous and that exact delegate timing is covered deterministically by `LBLoadingVisibilityDelayDelegateTest` on a virtual-time dispatcher.

Test-only; no production code touched, so no module version bump or CHANGELOG entry. Nothing muted, skipped, ignored or retried. `detekt` green; the class also ran 4× consecutively green on a local API 35 emulator.

## CI verification

Five consecutive green builds on `pull/332/merge`, all on `138bc2c`:

1. https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_PullRequest/43711 (#776)
2. https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_PullRequest/43712 (#777)
3. https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_PullRequest/43713 (#778)
4. https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_PullRequest/43714 (#779)
5. https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_PullRequest/43715 (#780)

Earlier on `b29e950` (fix 1 only): #773 and #774 green, #775 red on `hide_before_delay` — that reset the streak and produced fix 2.