### PR TITLE
fix: start SyncRunner runs lazily to publish the handle first

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres    
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+```
+Synchronization Core 2.0.0-rc03
+Synchronization Events 2.0.0-rc03
+Synchronization Core-Datastore 2.0.0-rc03
+Synchronization Core-Room 2.0.0-rc03
+Synchronization Parse-Room 2.0.0-rc03
+```
+
+- Fixed a race in `SyncRunner` where a run whose block completed without suspending — or whose body was
+  dispatched eagerly by a multi-threaded dispatcher — could observe its own `lateinit` run handle before
+  it was assigned, throwing `UninitializedPropertyAccessException` out of the runner's scope and leaving
+  `run(...)` awaiters hanging. The run coroutine is now started lazily, after the handle is published.
+- Bumped the modules depending on `synchronization-core` so consumers pinning every synchronization
+  artifact to a single version can resolve the fix.
+
 ## 2026-07-28
 
 ```

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -85,11 +85,11 @@ object AndroidConfig {
     const val MONITORING_OKHTTP_VERSION: String = MONITORING_CORE_VERSION
     const val MONITORING_ROOM_VERSION: String = MONITORING_CORE_VERSION
     const val MONITORING_UI_VERSION: String = MONITORING_CORE_VERSION
-    const val SYNCHRONIZATION_CORE_VERSION: String = "2.0.0-rc02"
-    const val SYNCHRONIZATION_EVENTS_VERSION: String = "2.0.0-rc02"
-    const val SYNCHRONIZATION_CORE_DATASTORE_VERSION: String = "2.0.0-rc02"
-    const val SYNCHRONIZATION_CORE_ROOM_VERSION: String = "2.0.0-rc02"
-    const val SYNCHRONIZATION_PARSE_ROOM_VERSION: String = "2.0.0-rc02"
+    const val SYNCHRONIZATION_CORE_VERSION: String = "2.0.0-rc03"
+    const val SYNCHRONIZATION_EVENTS_VERSION: String = "2.0.0-rc03"
+    const val SYNCHRONIZATION_CORE_DATASTORE_VERSION: String = "2.0.0-rc03"
+    const val SYNCHRONIZATION_CORE_ROOM_VERSION: String = "2.0.0-rc03"
+    const val SYNCHRONIZATION_PARSE_ROOM_VERSION: String = "2.0.0-rc03"
 
     val JDK_VERSION: JavaVersion = JavaVersion.VERSION_21
     val JVM_TARGET: JvmTarget = JvmTarget.JVM_21

--- a/common/synchronization/synchronization-core/src/commonMain/kotlin/studio/lunabee/synchronization/runner/SyncRunner.kt
+++ b/common/synchronization/synchronization-core/src/commonMain/kotlin/studio/lunabee/synchronization/runner/SyncRunner.kt
@@ -19,6 +19,7 @@ package studio.lunabee.synchronization.runner
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
@@ -133,13 +134,19 @@ class SyncRunner(
      * settling *before* completing the result deferred so any awaiter that resumes already sees
      * consistent state. On cancellation it still completes [result] (so awaiters never hang) and still
      * settles, under [NonCancellable]. Must be called while holding [mutex].
+     *
+     * The job is started [lazily][CoroutineStart.LAZY] and only started once [handle] has been assigned:
+     * the coroutine body passes its own handle to [settle], so an eagerly dispatched body could observe
+     * the handle before assignment. That happens whenever [block] completes without suspending or a
+     * multi-threaded dispatcher picks the body up immediately, and surfaces as an
+     * [UninitializedPropertyAccessException] escaping [scope].
      */
     private fun startRunLocked(
         block: suspend () -> LBResult<Unit>,
         result: CompletableDeferred<LBResult<Unit>>,
     ): RunHandle {
         lateinit var handle: RunHandle
-        val job = scope.launch {
+        val job = scope.launch(start = CoroutineStart.LAZY) {
             val outcome: LBResult<Unit> = try {
                 block()
             } catch (cancellation: CancellationException) {
@@ -154,6 +161,7 @@ class SyncRunner(
             result.complete(outcome)
         }
         handle = RunHandle(job = job, result = result)
+        job.start()
         return handle
     }
 

--- a/common/synchronization/synchronization-core/src/commonTest/kotlin/studio/lunabee/synchronization/runner/SyncRunnerTest.kt
+++ b/common/synchronization/synchronization-core/src/commonTest/kotlin/studio/lunabee/synchronization/runner/SyncRunnerTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
@@ -292,6 +293,31 @@ class SyncRunnerTest {
 
         scope.cancel()
     }
+
+    @Test
+    fun a_run_completing_without_suspending_on_an_eager_dispatcher_does_not_leak_an_uninitialized_handle() =
+        runTest {
+            // UnconfinedTestDispatcher runs the launched body eagerly, before `scope.launch` returns — the
+            // window in which `startRunLocked` had not yet assigned its `handle`. Combined with a block that
+            // never suspends, this reproduces the UninitializedPropertyAccessException the LAZY start fixes.
+            val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            val runner = SyncRunner(scope = scope, retryDelay = { null })
+            var invocations = 0
+
+            val result: LBResult<Unit> = runner.run {
+                invocations++
+                LBResult.Success(Unit)
+            }
+
+            assertEquals(expected = 1, actual = invocations)
+            assertTrue(result is LBResult.Success, "expected a Success result")
+
+            // The runner must still be usable: a leaked handle would have left `inFlight` inconsistent.
+            val second: LBResult<Unit> = runner.run { LBResult.Success(Unit) }
+            assertTrue(second is LBResult.Success, "runner should stay reusable after an eager run")
+
+            scope.cancel()
+        }
 
     /**
      * Drives [body] with a [SyncRunner] whose scope runs on the test scheduler, so all of the runner's


### PR DESCRIPTION
## Description

`SyncRunner.startRunLocked` declared `lateinit var handle: RunHandle`, launched the run coroutine, and only *then* assigned the handle. The coroutine body passes its own handle to `settle(...)`, so an eagerly dispatched body could read `handle` before it was assigned:

```kotlin
lateinit var handle: RunHandle
val job = scope.launch {          // body may run right here
    ...
    settle(handle, outcome, ...)  // <- reads handle
}
handle = RunHandle(job, result)   // <- assigned only now
```

Because the throw happened before `result.complete(...)`, this was a double failure: `UninitializedPropertyAccessException` escaped the runner's scope **and** every `run(...)` awaiter hung forever.

Fixed by starting the job with `CoroutineStart.LAZY` and calling `job.start()` after the handle is published.

## Motivation and context

Hit in production (BB_Hotel, `synchronization-core 2.0.0-rc02`) as a fatal crash on a cold start with no connectivity:

```
Fatal Exception: lateinit property handle has not been initialized
       at studio.lunabee.synchronization.runner.SyncRunner$startRunLocked$job$1.invokeSuspend(SyncRunner.java:153)
```

The window opens whenever the block completes without suspending, or a multi-threaded dispatcher picks the body up immediately (the report shows `DefaultDispatcher-worker`). Offline, the sync block fails fast with no suspension point, which makes it reliably reachable rather than rare.

## How has this been tested?

Added `a_run_completing_without_suspending_on_an_eager_dispatcher_does_not_leak_an_uninitialized_handle`.

The existing tests all use `StandardTestDispatcher`, which defers coroutine bodies — that is precisely why this race was never caught. The regression test uses `UnconfinedTestDispatcher` (eager) plus a non-suspending block.

Verified it fails without the fix and passes with it. Baseline run, fix reverted, test present:

```
SyncRunnerTest[jvm] > a_run_completing_without_suspending_on_an_eager_dispatcher_does_not_leak_an_uninitialized_handle()[jvm] FAILED
    kotlinx.coroutines.test.UncompletedCoroutinesError
	Suppressed: kotlin.UninitializedPropertyAccessException: lateinit property handle has not been initialized
		at studio.lunabee.synchronization.runner.SyncRunner$startRunLocked$job$1.invokeSuspend(SyncRunner.kt:153)
		at studio.lunabee.synchronization.runner.SyncRunner.startRunLocked(SyncRunner.kt:142)
```

Same frame as the production crash. With the fix, all 11 tests in the module pass.

```bash
./gradlew :synchronization-core:jvmTest                                    # 11/11 pass
./gradlew detekt -Pstudio.lunabee.detekt.skipDependencySorting             # clean
./gradlew :synchronization-{core,events,core-room,core-datastore,parse-room}:PrintCoordinates
                                                                           # all five report 2.0.0-rc03
```

Not run: the iOS targets, and no consumer-side verification against BB_Hotel (would need `publishToMavenLocal`).

## Versioning note

All five synchronization artifacts are bumped `2.0.0-rc02` → `2.0.0-rc03`, not just `synchronization-core`. The other four each depend on core (`api` for `core-room` / `core-datastore` / `parse-room`, `implementation` for `events`), and consumers pin the whole set through one version ref — BB_Hotel's catalog is:

```toml
synchronization = "2.0.0-rc02"
lbsynchronization-core      = { …, version.ref = "synchronization" }
lbsynchronization-core-room = { …, version.ref = "synchronization" }
lbsynchronization-events    = { …, version.ref = "synchronization" }
```

A core-only bump would have made that consumer resolve `synchronization-core-room:2.0.0-rc03` and `synchronization-events:2.0.0-rc03` — coordinates that were never published. This also matches the `AGENTS.MD` rule that a module whose transitive dependency moves gets bumped too.

## Checklist

- [x] Conventional-Commits, one concern per commit (fix + version bump split)
- [x] `CHANGELOG.MD` updated
- [x] All five synchronization modules bumped `2.0.0-rc02` → `2.0.0-rc03` (patch on an RC; no API change)
- [x] KDoc updated on `startRunLocked` explaining why the start is lazy
- [x] Detekt clean, no suppressions
- [x] License headers unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)