### PR TITLE
fix: LbcImage ImageDrawable preview rendering and uiMode override

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres    
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 2026-08-24
+
+```
+LbcImage 1.9.2
+```
+
+- Fixed `LbcImage` rendering nothing for `LbcImageSpec.ImageDrawable` in Compose previews: Coil skips
+  its request in inspection mode, so the drawable is now passed as the request placeholder there.
+- Fixed `LbcImageSpec.ImageDrawable.uiMode` overriding the whole `Configuration.uiMode` field: the device ui mode type
+  (car, television, watch…) is now preserved and only the masks set by the caller are overridden.
+
+## 2026-08-20
 
 ```
 Synchronization Core 2.0.0-rc03
@@ -13,7 +24,6 @@ Synchronization Events 2.0.0-rc03
 Synchronization Core-Datastore 2.0.0-rc03
 Synchronization Core-Room 2.0.0-rc03
 Synchronization Parse-Room 2.0.0-rc03
-LbcImage 1.9.2
 ```
 
 - Fixed a race in `SyncRunner` where a run whose block completed without suspending — or whose body was
@@ -22,10 +32,6 @@ LbcImage 1.9.2
   `run(...)` awaiters hanging. The run coroutine is now started lazily, after the handle is published.
 - Bumped the modules depending on `synchronization-core` so consumers pinning every synchronization
   artifact to a single version can resolve the fix.
-- Fixed `LbcImage` rendering nothing for `LbcImageSpec.ImageDrawable` in Compose previews: Coil skips
-  its request in inspection mode, so the drawable is now passed as the request placeholder there.
-- Fixed `LbcImageSpec.ImageDrawable.uiMode` overriding the whole `Configuration.uiMode` field: the device ui mode type
-  (car, television, watch…) is now preserved and only the masks set by the caller are overridden.
 
 ## 2026-07-28
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -24,6 +24,8 @@ LbcImage 1.9.2
   artifact to a single version can resolve the fix.
 - Fixed `LbcImage` rendering nothing for `LbcImageSpec.ImageDrawable` in Compose previews: Coil skips
   its request in inspection mode, so the drawable is now passed as the request placeholder there.
+- Fixed `LbcImageSpec.ImageDrawable.uiMode` overriding the whole `Configuration.uiMode` field: the device ui mode type
+  (car, television, watch…) is now preserved and only the masks set by the caller are overridden.
 
 ## 2026-07-28
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,6 +13,7 @@ Synchronization Events 2.0.0-rc03
 Synchronization Core-Datastore 2.0.0-rc03
 Synchronization Core-Room 2.0.0-rc03
 Synchronization Parse-Room 2.0.0-rc03
+LbcImage 1.9.2
 ```
 
 - Fixed a race in `SyncRunner` where a run whose block completed without suspending — or whose body was
@@ -21,6 +22,8 @@ Synchronization Parse-Room 2.0.0-rc03
   `run(...)` awaiters hanging. The run coroutine is now started lazily, after the handle is published.
 - Bumped the modules depending on `synchronization-core` so consumers pinning every synchronization
   artifact to a single version can resolve the fix.
+- Fixed `LbcImage` rendering nothing for `LbcImageSpec.ImageDrawable` in Compose previews: Coil skips
+  its request in inspection mode, so the drawable is now passed as the request placeholder there.
 
 ## 2026-07-28
 

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -62,7 +62,7 @@ object AndroidConfig {
     const val LBCUIFIELD_PHONEPICKER_VERSION: String = LBCUIFIELD_CORE_VERSION
     const val LBCUIFIELD_COUNTRYPICKER_VERSION: String = LBCUIFIELD_CORE_VERSION
     const val LBCUIFIELD_FORM_VERSION: String = "0.9.0"
-    const val LBCIMAGE_VERSION: String = "1.9.1"
+    const val LBCIMAGE_VERSION: String = "1.9.2"
     const val LBCGLANCE_VERSION: String = "1.6.0"
     const val LBCPRESENTER_VERSION: String = "2.0.0-rc01"
     const val LBCPRESENTER_ANNOTATIONS_VERSION: String = "2.0.0-rc01"

--- a/compose/image/src/main/kotlin/studio/lunabee/compose/image/LbcImage.kt
+++ b/compose/image/src/main/kotlin/studio/lunabee/compose/image/LbcImage.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.painterResource
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
@@ -240,6 +241,20 @@ private fun UriImage(
     }
 }
 
+/**
+ * The [Configuration.uiMode] field packs both the type and the night masks, so overriding it as a whole would drop the
+ * device values (car, television, watch…) not set by the caller. Only override the masks actually set on [override].
+ */
+private fun mergeUiMode(current: Int, override: Int): Int {
+    val type = (override and Configuration.UI_MODE_TYPE_MASK)
+        .takeIf { it != Configuration.UI_MODE_TYPE_UNDEFINED }
+        ?: (current and Configuration.UI_MODE_TYPE_MASK)
+    val night = (override and Configuration.UI_MODE_NIGHT_MASK)
+        .takeIf { it != Configuration.UI_MODE_NIGHT_UNDEFINED }
+        ?: (current and Configuration.UI_MODE_NIGHT_MASK)
+    return type or night
+}
+
 @Composable
 private fun DrawableImage(
     imageSpec: LbcImageSpec.ImageDrawable,
@@ -252,13 +267,15 @@ private fun DrawableImage(
     errorPainter: Painter?,
 ) {
     val context = LocalContext.current
+    val resources = LocalResources.current
+
     // Resolve the drawable through a configuration context so Coil picks the right uiMode (day/night) variant.
-    val requestContext = remember(context, imageSpec.uiMode) {
+    val requestContext = remember(context, resources.configuration, imageSpec.uiMode) {
         if (imageSpec.uiMode == Configuration.UI_MODE_TYPE_UNDEFINED) {
             context
         } else {
-            val configuration = Configuration().apply {
-                uiMode = imageSpec.uiMode
+            val configuration = Configuration(resources.configuration).apply {
+                uiMode = mergeUiMode(current = uiMode, override = imageSpec.uiMode)
             }
             context.createConfigurationContext(configuration)
         }

--- a/compose/image/src/main/kotlin/studio/lunabee/compose/image/LbcImage.kt
+++ b/compose/image/src/main/kotlin/studio/lunabee/compose/image/LbcImage.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
@@ -262,6 +263,12 @@ private fun DrawableImage(
             context.createConfigurationContext(configuration)
         }
     }
+    // Coil skips its request in inspection mode and only draws the loading painter, hence the preview placeholder.
+    val placeholder: Painter? = if (LocalInspectionMode.current) {
+        painterResource(id = imageSpec.drawableRes)
+    } else {
+        null
+    }
     // Let Coil load the drawable: it downsamples to the layout size instead of decoding the full bitmap.
     AsyncImage(
         model = ImageRequest
@@ -272,6 +279,7 @@ private fun DrawableImage(
         modifier = modifier,
         alignment = alignment,
         contentScale = contentScale,
+        placeholder = placeholder,
         error = errorPainter,
         onError = onState,
         onLoading = onState,


### PR DESCRIPTION
## 📜 Description

Two fixes on `LbcImage` for `LbcImageSpec.ImageDrawable` (`LbcImage 1.9.2`).

**Previews rendered nothing.** Coil skips its image request when `LocalInspectionMode` is on and only draws the loading painter, so an `ImageDrawable` showed as an empty box in `@Preview`. The drawable is now passed as the request placeholder in inspection mode.

**Forcing `uiMode` clobbered the device configuration.** The configuration context used to resolve the drawable was built from an empty `Configuration()`, losing the device locale, density and screen size, and `uiMode` was assigned as a whole — that field packs both the type and the night masks, so forcing night also wiped the ui mode type (car, television, watch). The current configuration is now copied and only the masks set by the caller are overridden. The remembered context is keyed on the configuration as well, since it is read inside the calculation.

## 💡 Motivation and Context

`LbcImage` moved to Coil for `ImageDrawable` in 1.9.1 to downsample drawables to the layout size instead of decoding the full bitmap. That made every `ImageDrawable` invisible in Compose previews, which is a bad regression for a UI library: consumers design their screens against previews.

The `uiMode` bug dates back to the introduction of the parameter. It only shows on devices that set a ui mode type, or when the drawable resolution depends on locale, density or screen size qualifiers.

### Known limitation

Forcing `uiMode` is honored on device only, never inside a Compose preview: Layoutlib's `BridgeContext.createConfigurationContext` logs a fidelity warning (`We do not currently support #createConfigurationContext.`) and returns the same context, so the render session's own configuration always wins. The `demo-compose` preview therefore shows the three `sun_moon` variants identically. Nothing in the Android API routes around it — Layoutlib resolves resources through the `RenderResources` bound to the render session.

## 💚 How did you test it?

- https://github.com/LunabeeStudio/RunMotion_Android/pull/1083

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)