### PR TITLE
feature/block-multi-nav

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -8,6 +8,6 @@
   </component>
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.4.0" />
+    <option name="version" value="2.4.10" />
   </component>
 </project>

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres    
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2026-08-31
+
+```
+Lbcpresenter 2.0.0
+LbcpresenterAnnotations 2.0.0
+LbcpresenterKoin 2.0.0
+```
+
+- `LBPresenter` now rejects navigation requests coming from a screen that already navigated and is no longer resumed, and
+  requests emitted while another navigation is still pending. This blocks the duplicated navigations caused by button flooding
+  (double tap or several clickable elements triggering navigation within the same frame).
+
 ## 2026-08-24
 
 ```

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,6 +13,15 @@ LbcpresenterAnnotations 2.0.0
 LbcpresenterKoin 2.0.0
 ```
 
+- Introduce presenter v2 generated reducer factories with the new `lbcpresenter-annotations` and `lbcpresenter-ksp` modules, plus optional
+  generated Koin reducer modules
+- **break:** Replace `LBSinglePresenter.initReducer()` with `createReducer(context)` and add `LBFactorySinglePresenter` for reducer
+  factories injected by DI
+- Add [MIGRATION_V2.MD](compose/presenter/MIGRATION_V2.MD) to help client projects migrate and keep generated factories and Koin bindings
+  aligned with reducer visibility, qualifiers, and multiplatform / incremental KSP builds
+
+_Changes from presenter 2.0.0-rc01_
+
 - `LBPresenter` now rejects navigation requests coming from a screen that already navigated and is no longer resumed, and
   requests emitted while another navigation is still pending. This blocks the duplicated navigations caused by button flooding
   (double tap or several clickable elements triggering navigation within the same frame).

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -64,9 +64,9 @@ object AndroidConfig {
     const val LBCUIFIELD_FORM_VERSION: String = "0.9.0"
     const val LBCIMAGE_VERSION: String = "1.9.2"
     const val LBCGLANCE_VERSION: String = "1.6.0"
-    const val LBCPRESENTER_VERSION: String = "2.0.0-rc01"
-    const val LBCPRESENTER_ANNOTATIONS_VERSION: String = "2.0.0-rc01"
-    const val LBCPRESENTER_KOIN_VERSION: String = "2.0.0-rc01"
+    const val LBCPRESENTER_VERSION: String = "2.0.0"
+    const val LBCPRESENTER_ANNOTATIONS_VERSION: String = "2.0.0"
+    const val LBCPRESENTER_KOIN_VERSION: String = "2.0.0"
     const val LBCPRESENTER_KSP_VERSION: String = "2.0.0-rc04"
     const val LBCPRESENTER_KOIN_KSP_VERSION: String = LBCPRESENTER_KSP_VERSION
     const val LBCNAVIGATION_VERSION: String = "1.1.0"

--- a/compose/presenter/presenter/src/main/kotlin/studio/lunabee/compose/presenter/LBPresenter.kt
+++ b/compose/presenter/presenter/src/main/kotlin/studio/lunabee/compose/presenter/LBPresenter.kt
@@ -54,6 +54,18 @@ abstract class LBPresenter<UiState : PresenterUiState, NavScope : Any, Action>(
 ) : ViewModel() {
 
     /**
+     * Last known lifecycle state of the screen hosting this presenter.
+     */
+    @Volatile
+    private var lifecycleState: Lifecycle.State = Lifecycle.State.INITIALIZED
+
+    /**
+     * Set as soon as a navigation is performed, reset when the screen gets resumed again.
+     */
+    @Volatile
+    private var hasNavigated: Boolean = false
+
+    /**
      * Channel to send user actions to the active reducer.
      */
     private val userActionChannel: Channel<Action> = Channel(Channel.UNLIMITED)
@@ -83,12 +95,18 @@ abstract class LBPresenter<UiState : PresenterUiState, NavScope : Any, Action>(
         extraBufferCapacity = 10,
     )
 
-    private fun consumeNavigation() {
-        navigation.value = null
-    }
-
     private fun performNavigation(navigateAction: NavScope.() -> Unit) {
-        navigation.value = navigateAction
+        val isLeavingScreen = hasNavigated && !lifecycleState.isAtLeast(Lifecycle.State.RESUMED)
+        when {
+            navigation.value != null -> log { "Reject navigation, another one is already pending" }
+
+            isLeavingScreen -> log { "Reject navigation due to lifecycle state: $lifecycleState" }
+
+            else -> {
+                hasNavigated = true
+                navigation.value = navigateAction
+            }
+        }
     }
 
     private fun useActivity(action: suspend (Activity) -> Unit) {
@@ -150,12 +168,22 @@ abstract class LBPresenter<UiState : PresenterUiState, NavScope : Any, Action>(
             LaunchedEffect(navigation) {
                 log { "Running navigation" }
                 it(navScope)
-                consumeNavigation()
+                this@LBPresenter.navigation.value = null
             }
         }
 
         val activity by rememberUpdatedState(LocalActivity.current)
         val lifecycleOwner = LocalLifecycleOwner.current
+        LaunchedEffect(lifecycleOwner) {
+            lifecycleOwner.lifecycle.currentStateFlow.collect { state ->
+                log { "$lifecycleOwner -> ${state.name}" }
+                lifecycleState = state
+                if (state.isAtLeast(Lifecycle.State.RESUMED)) {
+                    hasNavigated = false
+                }
+            }
+        }
+
         LaunchedEffect(lifecycleOwner) {
             log { "Starting activity effect" }
             lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {


### PR DESCRIPTION
## 📜 Description

`LBPresenter.performNavigation` now rejects a navigation request when:

- another navigation is still pending (not yet consumed by the composable) — covers the same-frame flood;
- the presenter already navigated once and its screen is no longer `RESUMED` — covers later taps, since `NavDisplay` caps the scene lifecycle to `STARTED` while a transition runs or an overlay is displayed.

The first navigation of a presenter is always allowed, so a screen redirecting during its own enter transition (splash-like) or a navigation triggered while the app is backgrounded still behaves as before. The `hasNavigated` latch is reset every time the screen goes back to `RESUMED`.

The lifecycle state is tracked from a `LaunchedEffect` collecting `Lifecycle.currentStateFlow` rather than read during composition: no write from the composition body, and the presenter content no longer recomposes on every lifecycle change. Both fields are `@Volatile` since `performNavigation` is called from the reducer coroutine.

Presenter, annotations and Koin modules are promoted from `2.0.0-rc01` to `2.0.0`.

## 💡 Motivation and Context

Rapid taps — a double tap on the same button, or two navigating elements pressed within the same frame — could push the same destination twice. Whether it reproduces depends on timing: the reducer can handle both actions before the navigation transition has started, so both requests reach the back stack. That is why only some apps hit the issue.

## 💚 How did you test it?

`./gradlew :compose:presenter:testDebugUnitTest detekt -Pstudio.lunabee.detekt.skipDependencySorting`

- Tested in LIDF

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 📸 Screenshots / GIFs


https://github.com/user-attachments/assets/de7f0b16-39ac-461e-b87b-35dfc48fe2ef



🤖 Generated with [Claude Code](https://claude.com/claude-code)